### PR TITLE
feat: Create a web page to download PKG files

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,54 @@
+body {
+    font-family: sans-serif;
+    background-color: #f0f2f5;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    width: 90%;
+    max-width: 500px;
+}
+
+h1 {
+    color: #1877f2;
+    margin-bottom: 1rem;
+}
+
+p {
+    color: #606770;
+    margin-bottom: 2rem;
+}
+
+#pkg-url {
+    width: 100%;
+    padding: 0.8rem;
+    border: 1px solid #dddfe2;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+    box-sizing: border-box;
+}
+
+#download-btn {
+    width: 100%;
+    padding: 0.8rem;
+    background-color: #1877f2;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+#download-btn:hover {
+    background-color: #166fe5;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PS4 PKG Downloader</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>PS4 PKG Downloader</h1>
+        <p>Enter the URL of the PKG file you want to download.</p>
+        <input type="text" id="pkg-url" placeholder="PKG File URL">
+        <button id="download-btn">Download</button>
+    </div>
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const downloadBtn = document.getElementById('download-btn');
+    const pkgUrlInput = document.getElementById('pkg-url');
+
+    downloadBtn.addEventListener('click', () => {
+        const pkgUrl = pkgUrlInput.value.trim();
+
+        if (pkgUrl) {
+            // For PS4, a direct redirection might be more reliable
+            window.location.href = pkgUrl;
+        } else {
+            alert('Please enter a PKG file URL.');
+        }
+    });
+});


### PR DESCRIPTION
This commit introduces a simple web application that allows users to download PKG files directly from their browser. This is particularly useful for PS4 users who want to download PKGs from the PS4 browser.

The application consists of:
- index.html: The main page with an input for the PKG URL and a download button.
- css/style.css: Basic styling for the user interface.
- js/main.js: JavaScript to handle the download logic. When the user clicks the download button, it redirects the browser to the provided URL, which initiates the download.